### PR TITLE
Add functionality to truncate to 3 digits

### DIFF
--- a/rust/codelist-rs/src/codelist_factory.rs
+++ b/rust/codelist-rs/src/codelist_factory.rs
@@ -479,7 +479,6 @@ mod tests {
         let codelist_factory = CodeListFactory::new(codelist_options, metadata, codelist_type);
 
         assert!(!codelist_factory.codelist_options.allow_duplicates);
-        assert!(!codelist_factory.codelist_options.truncate_to_3_digits,);
         assert!(!codelist_factory.codelist_options.add_x_codes);
         assert_eq!(codelist_factory.codelist_options.code_column_name, "code".to_string());
         assert_eq!(codelist_factory.codelist_options.term_column_name, "term".to_string());
@@ -517,7 +516,6 @@ C03,Test Disease 3,Description 3";
         assert!(codelist.entries.iter().any(|e| e.code == "C03" && e.term == "Test Disease 3"));
 
         assert!(!codelist.codelist_options.allow_duplicates);
-        assert!(!codelist.codelist_options.truncate_to_3_digits);
         assert!(!codelist.codelist_options.add_x_codes);
         assert_eq!(codelist.codelist_options.code_column_name, "code".to_string());
         assert_eq!(codelist.codelist_options.term_column_name, "term".to_string());
@@ -745,7 +743,6 @@ A01"; // Missing columns
         assert!(codelist.entries.iter().any(|e| e.code == "C03" && e.term == "Test Disease 3"));
 
         assert!(!codelist.codelist_options.allow_duplicates);
-        assert!(!codelist.codelist_options.truncate_to_3_digits);
         assert!(!codelist.codelist_options.add_x_codes);
         assert_eq!(codelist.codelist_options.code_column_name, "code".to_string());
         assert_eq!(codelist.codelist_options.term_column_name, "term".to_string());

--- a/rust/codelist-rs/src/codelist_options.rs
+++ b/rust/codelist-rs/src/codelist_options.rs
@@ -6,14 +6,12 @@ use serde::{Deserialize, Serialize};
 ///
 /// # Fields
 /// * `allow_duplicates` - Whether to allow duplicates in the codelist
-/// * `truncate_to_3_digits` - Whether to truncate the code to 3 digits
 /// * `add_x_codes` - Whether to add x codes to the codelist
 /// * `code_column_name` - The name of the code column
 /// * `term_column_name` - The name of the term column
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq, Hash)]
 pub struct CodeListOptions {
     pub allow_duplicates: bool,
-    pub truncate_to_3_digits: bool, // ICD10 specific only
     pub add_x_codes: bool,
     pub code_column_name: String, // for csv files
     pub term_column_name: String, // for csv files
@@ -29,7 +27,6 @@ impl Default for CodeListOptions {
     fn default() -> Self {
         Self {
             allow_duplicates: false,
-            truncate_to_3_digits: false,
             add_x_codes: false,
             code_column_name: "code".to_string(),
             term_column_name: "term".to_string(),
@@ -47,7 +44,6 @@ mod tests {
     fn test_default() {
         let options = CodeListOptions::default();
         assert!(!options.allow_duplicates);
-        assert!(!options.truncate_to_3_digits);
         assert!(!options.add_x_codes);
         assert_eq!(options.code_column_name, "code");
         assert_eq!(options.term_column_name, "term");

--- a/rust/codelist-rs/src/errors.rs
+++ b/rust/codelist-rs/src/errors.rs
@@ -123,4 +123,7 @@ pub enum CodeListError {
     #[error("CSV error: {0}")]
     #[construct(skip)]
     CSVError(#[from] csv::Error),
+
+    #[error("This CodeList cannot be truncated.")]
+    CodeListNotTruncatable,
 }

--- a/rust/codelist-rs/src/types.rs
+++ b/rust/codelist-rs/src/types.rs
@@ -21,6 +21,15 @@ pub enum CodeListType {
     OPCS,
 }
 
+impl CodeListType {
+    /// Is the `CodeListType` able to be truncated
+    // TODO: Make it a trait?
+    // Right now truncation only applies to ICD10 code lists, but ICD11 is coming.
+    pub fn is_truncatable(&self) -> bool {
+        matches!(self, CodeListType::ICD10)
+    }
+}
+
 impl FromStr for CodeListType {
     type Err = CodeListError;
     /// Convert a string to a CodeListType


### PR DESCRIPTION
- Check the codelist type, with useful error message if trying to do this on a non-ICD10 codelist.
    - added CodeListError::CodeListNotTruncatable

- Remove duplicates
    - added TermManagement::First

- Remove truncate_to_3_digits from CodelistOptions

This is the short term strategy discussed in ehrtools/codelist-tools#45