### PR TITLE
Add x codes

### DIFF
--- a/rust/codelist-rs/src/codelist.rs
+++ b/rust/codelist-rs/src/codelist.rs
@@ -283,7 +283,7 @@ impl CodeList {
             .filter(|entry| entry.code.len() == 4 && entry.code.ends_with("X"))
             .map(|entry| entry.code.clone())
             .collect::<HashSet<String>>();
-        
+
         let mut adds = vec![];
 
         for entry in &self.entries {
@@ -303,7 +303,7 @@ impl CodeList {
         for entry in &adds {
             self.add_entry(entry.code.clone(), entry.term.clone(), entry.comment.clone())?;
         }
-        
+
         Ok(())
     }
 }
@@ -712,11 +712,7 @@ mod tests {
 
         let mut expected_codelist =
             CodeList::new("test_codelist".to_string(), CodeListType::ICD10, metadata.clone(), None);
-        expected_codelist.add_entry(
-            "A10".to_string(),
-            "Cholera".to_string(),
-            None,
-        )?;
+        expected_codelist.add_entry("A10".to_string(), "Cholera".to_string(), None)?;
 
         expected_codelist.add_entry(
             "B01".to_string(),
@@ -724,19 +720,11 @@ mod tests {
             None,
         )?;
 
-        expected_codelist.add_entry(
-            "B0111".to_string(),
-            "TB".to_string(),
-            None,
-        )?;
+        expected_codelist.add_entry("B0111".to_string(), "TB".to_string(), None)?;
 
         let mut observed_codelist = expected_codelist.clone();
 
-        expected_codelist.add_entry(
-            "A10X".to_string(),
-            "Cholera".to_string(),
-            None,
-        )?;
+        expected_codelist.add_entry("A10X".to_string(), "Cholera".to_string(), None)?;
 
         expected_codelist.add_entry(
             "B01X".to_string(),
@@ -747,7 +735,7 @@ mod tests {
         observed_codelist.add_x_codes()?;
 
         assert_eq!(observed_codelist, expected_codelist);
-        
+
         Ok(())
     }
 
@@ -757,11 +745,7 @@ mod tests {
 
         let mut expected_codelist =
             CodeList::new("test_codelist".to_string(), CodeListType::ICD10, metadata.clone(), None);
-        expected_codelist.add_entry(
-            "A10".to_string(),
-            "Cholera".to_string(),
-            None,
-        )?;
+        expected_codelist.add_entry("A10".to_string(), "Cholera".to_string(), None)?;
 
         expected_codelist.add_entry(
             "B01".to_string(),
@@ -775,27 +759,19 @@ mod tests {
             None,
         )?;
 
-        expected_codelist.add_entry(
-            "B0111".to_string(),
-            "TB".to_string(),
-            None,
-        )?;
+        expected_codelist.add_entry("B0111".to_string(), "TB".to_string(), None)?;
 
         let mut observed_codelist = expected_codelist.clone();
 
-        expected_codelist.add_entry(
-            "A10X".to_string(),
-            "Cholera".to_string(),
-            None,
-        )?;
+        expected_codelist.add_entry("A10X".to_string(), "Cholera".to_string(), None)?;
 
         observed_codelist.add_x_codes()?;
 
         assert_eq!(observed_codelist, expected_codelist);
-        
+
         Ok(())
     }
-    
+
     #[test]
     fn test_add_x_codes_snomed() -> Result<(), CodeListError> {
         let metadata = create_test_metadata();
@@ -812,7 +788,6 @@ mod tests {
 
         Ok(())
     }
-
 }
 
 // add tests for get code, get code term entries

--- a/rust/codelist-rs/src/codelist.rs
+++ b/rust/codelist-rs/src/codelist.rs
@@ -357,7 +357,6 @@ mod tests {
 
         let codelist_options = CodeListOptions {
             allow_duplicates: true,
-            add_x_codes: true,
             code_column_name: "test_code".to_string(),
             term_column_name: "test_term".to_string(),
             code_field_name: "test_code".to_string(),
@@ -372,7 +371,6 @@ mod tests {
         );
 
         assert!(codelist.codelist_options.allow_duplicates);
-        assert!(codelist.codelist_options.add_x_codes);
         assert_eq!(codelist.codelist_options.code_field_name, "test_code".to_string());
         assert_eq!(codelist.codelist_options.term_field_name, "test_term".to_string());
         assert_eq!(codelist.codelist_options.code_column_name, "test_code".to_string());

--- a/rust/codelist-rs/src/codelist.rs
+++ b/rust/codelist-rs/src/codelist.rs
@@ -264,6 +264,48 @@ impl CodeList {
 
         Ok(())
     }
+
+    /// Add X to codelist entries that are 3 digits
+    ///
+    /// # Errors
+    /// * `CodeListError::CodeListNotXAddable` - If the codelist is not ICD10
+    pub fn add_x_codes(&mut self) -> Result<(), CodeListError> {
+        if !self.codelist_type.is_x_addable() {
+            return Err(CodeListError::CodeListNotXAddable {
+                codelist_type: self.codelist_type.to_string(),
+            });
+        }
+
+        // Keep track of all the four-digit codes ending in X
+        let mut exes = self
+            .entries
+            .iter()
+            .filter(|entry| entry.code.len() == 4 && entry.code.ends_with("X"))
+            .map(|entry| entry.code.clone())
+            .collect::<HashSet<String>>();
+        
+        let mut adds = vec![];
+
+        for entry in &self.entries {
+            if entry.code.len() == 3 {
+                let mut new_code = entry.code.clone();
+                new_code.push('X');
+
+                if exes.contains(&new_code) {
+                    continue;
+                }
+
+                exes.insert(new_code.clone());
+                adds.push(CodeEntry::new(new_code, entry.term.clone(), entry.comment.clone())?);
+            }
+        }
+
+        for entry in &adds {
+            self.add_entry(entry.code.clone(), entry.term.clone(), entry.comment.clone())?;
+        }
+        
+        Ok(())
+    }
 }
 
 pub enum TermManagement {
@@ -663,6 +705,114 @@ mod tests {
 
         Ok(())
     }
+
+    #[test]
+    fn test_add_x_codes_icd10() -> Result<(), CodeListError> {
+        let metadata = create_test_metadata();
+
+        let mut expected_codelist =
+            CodeList::new("test_codelist".to_string(), CodeListType::ICD10, metadata.clone(), None);
+        expected_codelist.add_entry(
+            "A10".to_string(),
+            "Cholera".to_string(),
+            None,
+        )?;
+
+        expected_codelist.add_entry(
+            "B01".to_string(),
+            "Typhoid and paratyphoid fevers".to_string(),
+            None,
+        )?;
+
+        expected_codelist.add_entry(
+            "B0111".to_string(),
+            "TB".to_string(),
+            None,
+        )?;
+
+        let mut observed_codelist = expected_codelist.clone();
+
+        expected_codelist.add_entry(
+            "A10X".to_string(),
+            "Cholera".to_string(),
+            None,
+        )?;
+
+        expected_codelist.add_entry(
+            "B01X".to_string(),
+            "Typhoid and paratyphoid fevers".to_string(),
+            None,
+        )?;
+
+        observed_codelist.add_x_codes()?;
+
+        assert_eq!(observed_codelist, expected_codelist);
+        
+        Ok(())
+    }
+
+    #[test]
+    fn test_add_x_codes_icd10_exists() -> Result<(), CodeListError> {
+        let metadata = create_test_metadata();
+
+        let mut expected_codelist =
+            CodeList::new("test_codelist".to_string(), CodeListType::ICD10, metadata.clone(), None);
+        expected_codelist.add_entry(
+            "A10".to_string(),
+            "Cholera".to_string(),
+            None,
+        )?;
+
+        expected_codelist.add_entry(
+            "B01".to_string(),
+            "Typhoid and paratyphoid fevers".to_string(),
+            None,
+        )?;
+
+        expected_codelist.add_entry(
+            "B01X".to_string(),
+            "Varicella [chickenpox]".to_string(),
+            None,
+        )?;
+
+        expected_codelist.add_entry(
+            "B0111".to_string(),
+            "TB".to_string(),
+            None,
+        )?;
+
+        let mut observed_codelist = expected_codelist.clone();
+
+        expected_codelist.add_entry(
+            "A10X".to_string(),
+            "Cholera".to_string(),
+            None,
+        )?;
+
+        observed_codelist.add_x_codes()?;
+
+        assert_eq!(observed_codelist, expected_codelist);
+        
+        Ok(())
+    }
+    
+    #[test]
+    fn test_add_x_codes_snomed() -> Result<(), CodeListError> {
+        let metadata = create_test_metadata();
+
+        let mut snomed_codelist = CodeList::new(
+            "test_codelist".to_string(),
+            CodeListType::SNOMED,
+            metadata.clone(),
+            None,
+        );
+
+        // A SNOMED list is not x_appendable
+        assert!(snomed_codelist.add_x_codes().is_err());
+
+        Ok(())
+    }
+
 }
 
 // add tests for get code, get code term entries

--- a/rust/codelist-rs/src/codelist_factory.rs
+++ b/rust/codelist-rs/src/codelist_factory.rs
@@ -479,7 +479,6 @@ mod tests {
         let codelist_factory = CodeListFactory::new(codelist_options, metadata, codelist_type);
 
         assert!(!codelist_factory.codelist_options.allow_duplicates);
-        assert!(!codelist_factory.codelist_options.add_x_codes);
         assert_eq!(codelist_factory.codelist_options.code_column_name, "code".to_string());
         assert_eq!(codelist_factory.codelist_options.term_column_name, "term".to_string());
         assert_eq!(codelist_factory.metadata, metadata_clone);
@@ -516,7 +515,6 @@ C03,Test Disease 3,Description 3";
         assert!(codelist.entries.iter().any(|e| e.code == "C03" && e.term == "Test Disease 3"));
 
         assert!(!codelist.codelist_options.allow_duplicates);
-        assert!(!codelist.codelist_options.add_x_codes);
         assert_eq!(codelist.codelist_options.code_column_name, "code".to_string());
         assert_eq!(codelist.codelist_options.term_column_name, "term".to_string());
         assert_eq!(codelist.metadata, factory.metadata);
@@ -743,7 +741,6 @@ A01"; // Missing columns
         assert!(codelist.entries.iter().any(|e| e.code == "C03" && e.term == "Test Disease 3"));
 
         assert!(!codelist.codelist_options.allow_duplicates);
-        assert!(!codelist.codelist_options.add_x_codes);
         assert_eq!(codelist.codelist_options.code_column_name, "code".to_string());
         assert_eq!(codelist.codelist_options.term_column_name, "term".to_string());
         assert_eq!(codelist.metadata, factory.metadata);

--- a/rust/codelist-rs/src/codelist_options.rs
+++ b/rust/codelist-rs/src/codelist_options.rs
@@ -6,13 +6,11 @@ use serde::{Deserialize, Serialize};
 ///
 /// # Fields
 /// * `allow_duplicates` - Whether to allow duplicates in the codelist
-/// * `add_x_codes` - Whether to add x codes to the codelist
 /// * `code_column_name` - The name of the code column
 /// * `term_column_name` - The name of the term column
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq, Hash)]
 pub struct CodeListOptions {
     pub allow_duplicates: bool,
-    pub add_x_codes: bool,
     pub code_column_name: String, // for csv files
     pub term_column_name: String, // for csv files
     pub code_field_name: String,  // for json files
@@ -27,7 +25,6 @@ impl Default for CodeListOptions {
     fn default() -> Self {
         Self {
             allow_duplicates: false,
-            add_x_codes: false,
             code_column_name: "code".to_string(),
             term_column_name: "term".to_string(),
             code_field_name: "code".to_string(),
@@ -44,7 +41,6 @@ mod tests {
     fn test_default() {
         let options = CodeListOptions::default();
         assert!(!options.allow_duplicates);
-        assert!(!options.add_x_codes);
         assert_eq!(options.code_column_name, "code");
         assert_eq!(options.term_column_name, "term");
         assert_eq!(options.code_field_name, "code");

--- a/rust/codelist-rs/src/errors.rs
+++ b/rust/codelist-rs/src/errors.rs
@@ -127,6 +127,6 @@ pub enum CodeListError {
     #[error("{codelist_type} is not truncatable to 3 digits.")]
     CodeListNotTruncatable { codelist_type: String },
 
-    #[error("{codelist_type} is not x-addable.")]
+    #[error("{codelist_type} cannot be transformed by having X added to the end of it")]
     CodeListNotXAddable { codelist_type: String },
 }

--- a/rust/codelist-rs/src/errors.rs
+++ b/rust/codelist-rs/src/errors.rs
@@ -126,4 +126,7 @@ pub enum CodeListError {
 
     #[error("{codelist_type} is not truncatable to 3 digits.")]
     CodeListNotTruncatable { codelist_type: String },
+
+    #[error("{codelist_type} is not x-addable.")]
+    CodeListNotXAddable { codelist_type: String },
 }

--- a/rust/codelist-rs/src/types.rs
+++ b/rust/codelist-rs/src/types.rs
@@ -28,6 +28,13 @@ impl CodeListType {
     pub fn is_truncatable(&self) -> bool {
         matches!(self, CodeListType::ICD10)
     }
+
+    /// Is the `CodeListType` able to have X added
+    // TODO: Make it a trait?
+    // Right now adding X only applies to ICD10 code lists, but ICD11 is coming.
+    pub fn is_x_addable(&self) -> bool {
+        matches!(self, CodeListType::ICD10)
+    }
 }
 
 impl FromStr for CodeListType {


### PR DESCRIPTION
- add CodeListError::CodeListNotXAddable
- add codelist_type.is_x_addable()
- add codelist.add_x_codes()
- remove add_x_codes from CodeListOptions

This addresses #44 