### PR TITLE
Derive Default for Metadata

### DIFF
--- a/rust/codelist-rs/examples/sandbox.rs
+++ b/rust/codelist-rs/examples/sandbox.rs
@@ -1,23 +1,11 @@
 // We are importing the CodeList struct from the codelist_rs crate
-use codelist_rs::{
-    codelist::CodeList,
-    errors::CodeListError,
-    metadata::{
-        categorisation_and_usage::CategorisationAndUsage, metadata::Metadata,
-        metadata_source::Source, provenance::Provenance, purpose_and_context::PurposeAndContext,
-        validation_and_review::ValidationAndReview,
-    },
-    types::CodeListType,
-};
+use codelist_rs::{codelist::CodeList, errors::CodeListError, types::CodeListType};
+
+use std::default::Default;
 
 fn main() -> Result<(), CodeListError> {
     // Metadata for the codelist
-    let metadata = Metadata::new(
-        Provenance::new(Source::ManuallyCreated, None),
-        CategorisationAndUsage::new(None, None, None),
-        PurposeAndContext::new(None, None, None),
-        ValidationAndReview::new(None, None, None, None, None),
-    );
+    let metadata = Default::default();
 
     // Create a new codelist
     let mut codelist =
@@ -26,7 +14,7 @@ fn main() -> Result<(), CodeListError> {
     codelist.add_entry("A00".to_string(), "Cholera".to_string(), None)?;
     codelist.add_entry("A01".to_string(), "Typhoid and paratyphoid fevers".to_string(), None)?;
 
-    println!("{codelist:?}");
+    println!("{codelist:#?}");
 
     Ok(())
 }

--- a/rust/codelist-rs/src/codelist.rs
+++ b/rust/codelist-rs/src/codelist.rs
@@ -327,22 +327,11 @@ impl FromStr for TermManagement {
 mod tests {
     use chrono::Utc;
     use indexmap::IndexSet;
+    use std::default::Default;
     use tempfile::TempDir;
 
     use super::*;
-    use crate::metadata::{
-        CategorisationAndUsage, Provenance, PurposeAndContext, Source, ValidationAndReview,
-    };
-
-    // Helper function to create test metadata
-    fn create_test_metadata() -> Metadata {
-        Metadata {
-            provenance: Provenance::new(Source::ManuallyCreated, None),
-            categorisation_and_usage: CategorisationAndUsage::new(None, None, None),
-            purpose_and_context: PurposeAndContext::new(None, None, None),
-            validation_and_review: ValidationAndReview::new(None, None, None, None, None),
-        }
-    }
+    use crate::metadata::Source;
 
     // Helper function to create a test codelist with two entries, default options
     // and test metadata
@@ -350,7 +339,7 @@ mod tests {
         let mut codelist = CodeList::new(
             "test_codelist".to_string(),
             CodeListType::ICD10,
-            create_test_metadata(),
+            Default::default(),
             None,
         );
         codelist.add_entry("R65.2".to_string(), "Severe sepsis".to_string(), None)?;
@@ -406,8 +395,6 @@ mod tests {
 
     #[test]
     fn test_create_codelist_custom_options() -> Result<(), CodeListError> {
-        let metadata = create_test_metadata();
-
         let codelist_options = CodeListOptions {
             allow_duplicates: true,
             code_column_name: "test_code".to_string(),
@@ -419,7 +406,7 @@ mod tests {
         let codelist = CodeList::new(
             "test_codelist".to_string(),
             CodeListType::ICD10,
-            metadata,
+            Default::default(),
             Some(codelist_options),
         );
 
@@ -463,7 +450,7 @@ mod tests {
         let mut codelist = CodeList::new(
             "test_codelist".to_string(),
             CodeListType::ICD10,
-            create_test_metadata(),
+            Default::default(),
             None,
         );
         codelist.add_entry("R65.2".to_string(), "Severe sepsis".to_string(), None)?;
@@ -640,7 +627,7 @@ mod tests {
 
     #[test]
     fn test_get_metadata() {
-        let metadata = create_test_metadata();
+        let metadata: Metadata = Default::default();
         let codelist =
             CodeList::new("test".to_string(), CodeListType::ICD10, metadata.clone(), None);
 
@@ -649,12 +636,10 @@ mod tests {
 
     #[test]
     fn test_truncate_to_3_digits_snomed() -> Result<(), CodeListError> {
-        let metadata = create_test_metadata();
-
         let mut snomed_codelist = CodeList::new(
             "test_codelist".to_string(),
             CodeListType::SNOMED,
-            metadata.clone(),
+            Default::default(),
             None,
         );
 
@@ -666,7 +651,7 @@ mod tests {
 
     #[test]
     fn test_truncate_to_3_digits_icd10_4_digits() -> Result<(), CodeListError> {
-        let metadata = create_test_metadata();
+        let metadata: Metadata = Default::default();
 
         let mut expected_codelist =
             CodeList::new("test_codelist".to_string(), CodeListType::ICD10, metadata.clone(), None);
@@ -677,7 +662,7 @@ mod tests {
         )?;
 
         let mut observed_codelist =
-            CodeList::new("test_codelist".to_string(), CodeListType::ICD10, metadata.clone(), None);
+            CodeList::new("test_codelist".to_string(), CodeListType::ICD10, metadata, None);
 
         observed_codelist.add_entry("B012".to_string(), "Varicella pneumonia".to_string(), None)?;
 
@@ -690,7 +675,7 @@ mod tests {
 
     #[test]
     fn test_truncate_to_3_digits_3_and_4_digits() -> Result<(), CodeListError> {
-        let metadata = create_test_metadata();
+        let metadata: Metadata = Default::default();
 
         let mut expected_codelist =
             CodeList::new("test_codelist".to_string(), CodeListType::ICD10, metadata.clone(), None);
@@ -701,7 +686,7 @@ mod tests {
         )?;
 
         let mut observed_codelist =
-            CodeList::new("test_codelist".to_string(), CodeListType::ICD10, metadata.clone(), None);
+            CodeList::new("test_codelist".to_string(), CodeListType::ICD10, metadata, None);
 
         observed_codelist.add_entry(
             "B01".to_string(),
@@ -719,10 +704,12 @@ mod tests {
 
     #[test]
     fn test_add_x_codes_icd10() -> Result<(), CodeListError> {
-        let metadata = create_test_metadata();
-
-        let mut expected_codelist =
-            CodeList::new("test_codelist".to_string(), CodeListType::ICD10, metadata.clone(), None);
+        let mut expected_codelist = CodeList::new(
+            "test_codelist".to_string(),
+            CodeListType::ICD10,
+            Default::default(),
+            None,
+        );
         expected_codelist.add_entry("A10".to_string(), "Cholera".to_string(), None)?;
 
         expected_codelist.add_entry(
@@ -752,10 +739,12 @@ mod tests {
 
     #[test]
     fn test_add_x_codes_icd10_exists() -> Result<(), CodeListError> {
-        let metadata = create_test_metadata();
-
-        let mut expected_codelist =
-            CodeList::new("test_codelist".to_string(), CodeListType::ICD10, metadata.clone(), None);
+        let mut expected_codelist = CodeList::new(
+            "test_codelist".to_string(),
+            CodeListType::ICD10,
+            Default::default(),
+            None,
+        );
         expected_codelist.add_entry("A10".to_string(), "Cholera".to_string(), None)?;
 
         expected_codelist.add_entry(
@@ -785,12 +774,10 @@ mod tests {
 
     #[test]
     fn test_add_x_codes_snomed() -> Result<(), CodeListError> {
-        let metadata = create_test_metadata();
-
         let mut snomed_codelist = CodeList::new(
             "test_codelist".to_string(),
             CodeListType::SNOMED,
-            metadata.clone(),
+            Default::default(),
             None,
         );
 

--- a/rust/codelist-rs/src/metadata/categorisation_and_usage.rs
+++ b/rust/codelist-rs/src/metadata/categorisation_and_usage.rs
@@ -9,7 +9,7 @@ use serde::{Deserialize, Serialize};
 // Internal imports
 use crate::errors::CodeListError;
 
-#[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
+#[derive(Clone, Debug, Default, PartialEq, Serialize, Deserialize)]
 pub struct CategorisationAndUsage {
     pub tags: HashSet<String>,
     pub usage: HashSet<String>,

--- a/rust/codelist-rs/src/metadata/metadata.rs
+++ b/rust/codelist-rs/src/metadata/metadata.rs
@@ -20,7 +20,7 @@ use crate::metadata::{
 /// * `purpose_and_context` - The purpose and context of the codelist
 /// * `validation_and_review` - The validation and review of the codelist
 
-#[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
+#[derive(Clone, Debug, Default, PartialEq, Serialize, Deserialize)]
 pub struct Metadata {
     pub provenance: Provenance,
     pub categorisation_and_usage: CategorisationAndUsage,

--- a/rust/codelist-rs/src/metadata/metadata_source.rs
+++ b/rust/codelist-rs/src/metadata/metadata_source.rs
@@ -9,10 +9,11 @@ use serde::{Deserialize, Serialize};
 use crate::errors::CodeListError;
 
 /// Enum to represent the different sources of the codelist
-#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq, Hash)]
+#[derive(Clone, Debug, Default, Serialize, Deserialize, PartialEq, Eq, Hash)]
 pub enum Source {
     LoadedFromFile,
     MappedFromAnotherCodelist,
+    #[default]
     ManuallyCreated,
 }
 

--- a/rust/codelist-rs/src/metadata/provenance.rs
+++ b/rust/codelist-rs/src/metadata/provenance.rs
@@ -20,6 +20,12 @@ pub struct Provenance {
     pub contributors: IndexSet<String>,
 }
 
+impl Default for Provenance {
+    fn default() -> Self {
+        Provenance::new(Source::ManuallyCreated, None)
+    }
+}
+
 impl Provenance {
     /// Create a new provenance
     ///

--- a/rust/codelist-rs/src/metadata/purpose_and_context.rs
+++ b/rust/codelist-rs/src/metadata/purpose_and_context.rs
@@ -6,7 +6,7 @@ use serde::{Deserialize, Serialize};
 // Internal imports
 use crate::errors::CodeListError;
 
-#[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
+#[derive(Clone, Debug, Default, PartialEq, Serialize, Deserialize)]
 pub struct PurposeAndContext {
     pub purpose: Option<String>,
     pub target_audience: Option<String>,

--- a/rust/codelist-rs/src/metadata/validation_and_review.rs
+++ b/rust/codelist-rs/src/metadata/validation_and_review.rs
@@ -7,7 +7,7 @@ use serde::{Deserialize, Serialize};
 // Internal imports
 use crate::errors::CodeListError;
 
-#[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
+#[derive(Clone, Debug, Default, PartialEq, Serialize, Deserialize)]
 pub struct ValidationAndReview {
     pub reviewed: bool,
     pub reviewer: Option<String>,


### PR DESCRIPTION
- choose the default for source
- impl Default for Provenance manually to get current timestamps
- update sandbox example to use defaults
- update tests accordingly

This addresses issue ehrtools/codelist-tools#66