### PR TITLE
Truncate drop_term

### DIFF
--- a/rust/codelist-rs/src/codelist.rs
+++ b/rust/codelist-rs/src/codelist.rs
@@ -414,7 +414,7 @@ impl CodeList {
             // entry depends on the term_management
             let (term, comment) = match term_management {
                 TermManagement::DropTerm => {
-                    (None, Some(format!("Truncated to 3 digits, term discarded")))
+                    (None, Some("Truncated to 3 digits, term discarded".to_string()))
                 }
 
                 TermManagement::First => (

--- a/rust/codelist-rs/src/errors.rs
+++ b/rust/codelist-rs/src/errors.rs
@@ -133,7 +133,7 @@ pub enum CodeListError {
     #[error("{codelist_type} cannot be truncated to 3 digits.")]
     CodeListNotTruncatable { codelist_type: String },
 
-    #[error("{term_management} is not known. Valid values are 'first'")]
+    #[error("{term_management} is not known. Valid values are 'first', 'drop_term'")]
     TermManagementNotKnown { term_management: String },
 
     #[error("{codelist_type} cannot be transformed by having X added to the end of it")]


### PR DESCRIPTION
Added the DropTerm option to TermManagement as in #87 

Updated the Python bindings too, which is good because I found a problem with error.rs back on the Rust side.

Closes #87 
